### PR TITLE
Unmount angular by using the proper rootScope

### DIFF
--- a/src/single-spa-angular1.js
+++ b/src/single-spa-angular1.js
@@ -9,9 +9,8 @@ const defaultOpts = {
 	// optional opts
 	uiRouter: false,
 	preserveGlobal: false,
+	elementId: '__single_spa_angular_1',
 };
-
-const SINGLE_SPA_ELEMENT_ID = '__single_spa_angular_1';
 
 export default function singleSpaAngular1(userOpts) {
 	if (typeof userOpts !== 'object') {
@@ -54,7 +53,7 @@ function mount() {
 
 		const containerEl = getContainerEl();
 		const bootstrapEl = document.createElement('div');
-		bootstrapEl.id = SINGLE_SPA_ELEMENT_ID;
+		bootstrapEl.id = opts.elementId;
 
 		containerEl.appendChild(bootstrapEl);
 
@@ -72,7 +71,7 @@ function mount() {
 
 function unmount() {
 	return new Promise((resolve, reject) => {
-		let rootElement = angular.element(getContainerEl().querySelector(`#${SINGLE_SPA_ELEMENT_ID}`));
+		let rootElement = angular.element(getContainerEl().querySelector(`#${opts.elementId}`));
 		let rootScope = rootElement.injector().get('$rootScope');
 
 		const result = rootScope.$destroy();

--- a/src/single-spa-angular1.js
+++ b/src/single-spa-angular1.js
@@ -68,7 +68,9 @@ function mount() {
 
 function unmount() {
 	return new Promise((resolve, reject) => {
-		let rootScope = angular.injector(['ng']).get('$rootScope');
+		let rootElement = angular.element(getContainerEl().childNodes[0]);
+		let rootScope = rootElement.scope();
+
 		const result = rootScope.$destroy();
 
 		getContainerEl().innerHTML = '';

--- a/src/single-spa-angular1.js
+++ b/src/single-spa-angular1.js
@@ -69,7 +69,7 @@ function mount() {
 function unmount() {
 	return new Promise((resolve, reject) => {
 		let rootElement = angular.element(getContainerEl().childNodes[0]);
-		let rootScope = rootElement.scope();
+		let rootScope = rootElement.injector().get('$rootScope');
 
 		const result = rootScope.$destroy();
 

--- a/src/single-spa-angular1.js
+++ b/src/single-spa-angular1.js
@@ -11,6 +11,8 @@ const defaultOpts = {
 	preserveGlobal: false,
 };
 
+const SINGLE_SPA_ELEMENT_ID = '__single_spa_angular_1';
+
 export default function singleSpaAngular1(userOpts) {
 	if (typeof userOpts !== 'object') {
 		throw new Error(`single-spa-angular1 requires a configuration object`);
@@ -52,6 +54,8 @@ function mount() {
 
 		const containerEl = getContainerEl();
 		const bootstrapEl = document.createElement('div');
+		bootstrapEl.id = SINGLE_SPA_ELEMENT_ID;
+
 		containerEl.appendChild(bootstrapEl);
 
 		if (opts.uiRouter) {
@@ -68,7 +72,7 @@ function mount() {
 
 function unmount() {
 	return new Promise((resolve, reject) => {
-		let rootElement = angular.element(getContainerEl().childNodes[0]);
+		let rootElement = angular.element(getContainerEl().querySelector(`#${SINGLE_SPA_ELEMENT_ID}`));
 		let rootScope = rootElement.injector().get('$rootScope');
 
 		const result = rootScope.$destroy();


### PR DESCRIPTION
It looks as though the way we were getting the rootScope is incorrect.

The following is true:

```js
angular.injector(['ng']).get('$rootScope') !== angular.injector(['ng']).get('$rootScope')
```

In other words, the rootScope is not the same each time it is queried with this method. Whereas this is true:

```js
angular.element(getContainerEl().childNodes[0]).scope() === angular.element(getContainerEl().childNodes[0]).scope()
```

The problem was noticed when calling `angular.injector(['ng']).get('$rootScope').$destroy()` no children components `.$on('$destroy')` events were getting fired. More importantly, the `$onInit` of components wasn't getting fired on remount. When switching to the new way of querying the `$rootScope` and calling `$destroy()` all events properly fire.