### PR TITLE
Fixing bug where getContainerEl was not getting called with opts

### DIFF
--- a/src/single-spa-angular1.js
+++ b/src/single-spa-angular1.js
@@ -69,7 +69,7 @@ function mount(opts) {
 
 function unmount(opts) {
 	return new Promise((resolve, reject) => {
-		let rootElement = angular.element(getContainerEl().querySelector(`#${opts.elementId}`));
+		let rootElement = angular.element(getContainerEl(opts).querySelector(`#${opts.elementId}`));
 		let rootScope = rootElement.injector().get('$rootScope');
 
 		const result = rootScope.$destroy();


### PR DESCRIPTION
See https://github.com/CanopyTax/single-spa-angular1/compare/fix-error?expand=1#diff-32cc56661412303f72a4145d98ad9a1fR87 for why this is necessary.

Version 2.2.1 of single-spa-angular1 had a variable called `opts` that was accessible globally to this es6 module. But then 2.2.2 removed that variable and requires you to pass the `opts` variable around. This particular line of code fell through the cracks.